### PR TITLE
README.md: fix settings filename in the development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ pnpm install && pnpm build
 $ cd ..
 # Copy necessary files to the backend folder
 $ cp -r website/dist assets/webpage && cp -r assets backend/assets 
-$ cp example.config.toml backend/example.toml 
+$ cp example.config.toml backend/config.toml 
 # Run the server
 $ cd backend
 $ cargo run


### PR DESCRIPTION
Building the backend fails, if you follow the development instructions in the [readme](https://github.com/Delta1925/simple-wkd/blob/7ab056c62bf5206208674902537e817c7cf167a3/README.md#development):

> [2024-08-29 08:24:54] [simple_wkd] DEBUG: Starting server...
[2024-08-29 08:24:54] [simple_wkd::settings] DEBUG: Parsing settings...
[2024-08-29 08:24:54] [simple_wkd::settings] ERROR: Unable to access settings file!
thread 'main' panicked at src/settings.rs:52:13:
Unable to access settings file!

The settings file is expected in `backend/config.toml`, but in the instructions it is copied to `backend/example.toml`:

> $ cp example.config.toml backend/example.toml 